### PR TITLE
大佬，发现您的项目引入了org.apache.httpcomponents:httpclient@4.5.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -170,7 +169,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -222,7 +221,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!--远程调用工具 优于httpClient restTemplate等-->


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache HttpClient信息泄露漏洞
缺陷组件：org.apache.httpcomponents:httpclient@4.5.2
漏洞编号：CVE-2020-13956
漏洞描述：HttpClient是美国阿帕奇（Apache）软件基金会的一个Java编写的访问HTTP资源的客户端程序。该程序用于使用HTTP协议访问网络资源。
Apache HttpClient存在信息泄露漏洞，该漏洞源于网络系统或产品在运行过程中存在配置等错误。目前没有详细的漏洞细节提供。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-24248
影响范围：(∞, 4.5.13)
最小修复版本：4.5.13
缺陷组件引入路径：com.javaboy:common@0.0.1-SNAPSHOT->org.apache.httpcomponents:httpclient@4.5.2
```
另外我运行这个项目时，IDE的安全插件提示还有27个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pc9198